### PR TITLE
Improve `API` class, add retry with `tenacity` (#4)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,5 +20,7 @@ SOURCE_TOOL_ID=
 TARGET_TOOL_ID=
 
 # For integration tests
+# Test account
+TEST_ACCOUNT_ID=
 # Test course
 TEST_COURSE_ID=

--- a/migration/api.py
+++ b/migration/api.py
@@ -39,7 +39,7 @@ class API:
         endpoint_type: EndpointType = EndpointType.REST,
         timeout: int = 10
     ):
-        headers = { 'Authorization': f'Bearer {key}' }
+        headers = {'Authorization': f'Bearer {key}'}
         self.client = httpx.Client(base_url=url + endpoint_type.value, headers=headers, timeout=timeout)
 
     @staticmethod

--- a/migration/api.py
+++ b/migration/api.py
@@ -1,11 +1,12 @@
 import logging
+from dataclasses import dataclass
 from enum import Enum
+from json import JSONDecodeError
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
-
 import httpx
-
+from tenacity import retry, stop_after_attempt, RetryCallState, retry_if_exception_type
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +15,27 @@ class EndpointType(Enum):
     REST = '/api/v1/'
 
 
+def log_retry(retry_state: RetryCallState):
+    logger.warning(f'Call attempt {retry_state.attempt_number} failed.')
+
+
+@dataclass
+class GetResponseData:
+    data: Any
+    next_page_params: dict[str, Any] | None
+
+
 class API:
     client: httpx.Client
 
-    def __init__(self, url: str, key: str, endpoint_type: EndpointType = EndpointType.REST):
+    def __init__(
+        self,
+        url: str,
+        key: str, endpoint_type: EndpointType = EndpointType.REST,
+        timeout: int = 10
+    ):
         headers = { 'Authorization': f'Bearer {key}' }
-        self.client = httpx.Client(base_url=url + endpoint_type.value, headers=headers)
+        self.client = httpx.Client(base_url=url + endpoint_type.value, headers=headers, timeout=timeout)
 
     @staticmethod
     def get_next_page_params(resp: httpx.Response) -> dict[str, Any] | None:
@@ -28,6 +44,42 @@ class API:
         else:
             query_params = parse_qs(urlparse(resp.links['next']['url']).query)
             return query_params
+
+    @retry(
+        stop=stop_after_attempt(4),
+        retry=retry_if_exception_type((httpx.HTTPError, JSONDecodeError)),
+        reraise=True,
+        after=log_retry
+    )
+    def get(self, url: str, params: dict[str, Any] | None = None) -> GetResponseData:
+        try:
+            resp = self.client.get(url=url, params=params)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.warning(f"HTTP Exception for {exc.request.url} - {exc}")
+            raise exc
+        # Check if decoding the JSON raises an error
+        try:
+            data = resp.json()
+        except JSONDecodeError as exc:
+            logger.warning('JSONDecodeError encountered')
+            raise exc
+        next_page_params = self.get_next_page_params(resp)
+        return GetResponseData(data, next_page_params)
+
+    @retry(
+        stop=stop_after_attempt(4),
+        retry=retry_if_exception_type(httpx.HTTPError),
+        reraise=True,
+        after=log_retry
+    )
+    def put(self, url: str, params: dict[str, Any] | None = None) -> None:
+        try:
+            resp = self.client.put(url=url, params=params)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.error(f"HTTP Exception for {exc.request.url} - {exc}")
+            raise exc
 
     def get_results_from_pages(
         self, endpoint: str, params: dict[str, Any] | None = None, page_size: int = 50, limit: int | None = None
@@ -45,20 +97,14 @@ class API:
 
         while more_pages:
             logger.debug(f'Params: {extra_params}')
-            try:
-                resp = self.client.get(url=endpoint, params=extra_params, timeout=10)
-                resp.raise_for_status()
-            except httpx.HTTPError as exc:
-                logger.error(f"HTTP Exception for {exc.request.url} - {exc}")
-                raise exc
-            results += resp.json()
-            next_page_params = API.get_next_page_params(resp)
-            if next_page_params is None:
+            data = self.get(url=endpoint, params=extra_params)
+            results += data.data
+            if data.next_page_params is None:
                 more_pages = False
             elif limit is not None and limit <= len(results):
                 more_pages = False
             else:
-                extra_params.update(next_page_params)
+                extra_params.update(data.next_page_params)
                 page_num += 1
 
         if limit is not None and len(results) > limit:

--- a/migration/api.py
+++ b/migration/api.py
@@ -18,7 +18,7 @@ class API:
     client: httpx.Client
 
     def __init__(self, url: str, key: str, endpoint_type: EndpointType = EndpointType.REST):
-        headers = { 'Authorization': f'Bearer {key}'}
+        headers = { 'Authorization': f'Bearer {key}' }
         self.client = httpx.Client(base_url=url + endpoint_type.value, headers=headers)
 
     @staticmethod
@@ -61,7 +61,7 @@ class API:
                 extra_params.update(next_page_params)
                 page_num += 1
 
-        if limit is not None:
+        if limit is not None and len(results) > limit:
             results = results[:limit]
 
         logger.debug(f'Number of results: {len(results)}')

--- a/migration/api.py
+++ b/migration/api.py
@@ -96,6 +96,7 @@ class API:
                 extra_params.update(data.next_page_params)
                 page_num += 1
 
+        # if limit is specified, slice off data if there is more than the limit
         if limit is not None and len(results) > limit:
             results = results[:limit]
 

--- a/migration/api.py
+++ b/migration/api.py
@@ -13,7 +13,10 @@ from tenacity import (
     stop_after_attempt
 )
 
+
 logger = logging.getLogger(__name__)
+
+MAX_ATTEMPT_NUM = 4
 
 
 class EndpointType(Enum):
@@ -21,7 +24,7 @@ class EndpointType(Enum):
 
 
 @dataclass
-class GetResponseData:
+class GetResponse:
     data: Any
     next_page_params: dict[str, Any] | None
 
@@ -32,7 +35,8 @@ class API:
     def __init__(
         self,
         url: str,
-        key: str, endpoint_type: EndpointType = EndpointType.REST,
+        key: str,
+        endpoint_type: EndpointType = EndpointType.REST,
         timeout: int = 10
     ):
         headers = { 'Authorization': f'Bearer {key}' }
@@ -47,20 +51,20 @@ class API:
             return query_params
 
     @retry(
-        stop=stop_after_attempt(4),
+        stop=stop_after_attempt(MAX_ATTEMPT_NUM),
         retry=retry_if_exception_type((httpx.HTTPError, JSONDecodeError)),
         reraise=True,
         before_sleep=before_sleep_log(logger, logging.WARN)
     )
-    def get(self, url: str, params: dict[str, Any] | None = None) -> GetResponseData:
+    def get(self, url: str, params: dict[str, Any] | None = None) -> GetResponse:
         resp = self.client.get(url=url, params=params)
         resp.raise_for_status()
         data = resp.json()
         next_page_params = self.get_next_page_params(resp)
-        return GetResponseData(data, next_page_params)
+        return GetResponse(data, next_page_params)
 
     @retry(
-        stop=stop_after_attempt(4),
+        stop=stop_after_attempt(MAX_ATTEMPT_NUM),
         retry=retry_if_exception_type((httpx.HTTPError, JSONDecodeError)),
         reraise=True,
         before_sleep=before_sleep_log(logger, logging.WARN)
@@ -86,14 +90,14 @@ class API:
 
         while more_pages:
             logger.debug(f'Params: {extra_params}')
-            data = self.get(url=endpoint, params=extra_params)
-            results += data.data
-            if data.next_page_params is None:
+            get_resp = self.get(url=endpoint, params=extra_params)
+            results += get_resp.data
+            if get_resp.next_page_params is None:
                 more_pages = False
             elif limit is not None and limit <= len(results):
                 more_pages = False
             else:
-                extra_params.update(data.next_page_params)
+                extra_params.update(get_resp.next_page_params)
                 page_num += 1
 
         # if limit is specified, slice off data if there is more than the limit

--- a/migration/manager.py
+++ b/migration/manager.py
@@ -6,6 +6,7 @@ import httpx
 
 from api import API
 from data import Course, ExternalTool, ExternalToolTab
+from utils import chunk_integer
 
 
 logger = logging.getLogger(__name__)
@@ -23,17 +24,16 @@ class AccountManager:
         return tools
 
     def get_courses_in_terms(self, term_ids: list[int], limit: int | None = None) -> list[Course]:
-        limit_per_term = None
         if limit is not None:
-            limit_per_term = limit // len(term_ids)
+            limit_chunks = chunk_integer(limit, len(term_ids))
 
         results: list[dict[str, Any]] = []
-        for term_id in term_ids:
+        for i, term_id in enumerate(term_ids):
             term_results = self.api.get_results_from_pages(
                 f'/accounts/{self.account_id}/courses',
                 params={ 'enrollment_term_id': term_id },
                 page_size=50,
-                limit=limit_per_term
+                limit=limit_chunks[i] if limit_chunks else None
             )
             results += term_results
         courses = [

--- a/migration/manager.py
+++ b/migration/manager.py
@@ -22,10 +22,10 @@ class AccountManager:
         tools = [ExternalTool(id=tool_dict['id'], name=tool_dict['name']) for tool_dict in results]
         return tools
 
-    def get_courses_in_terms(self, term_ids: list[int], bail_after: int | None = None) -> list[Course]:
+    def get_courses_in_terms(self, term_ids: list[int], limit: int | None = None) -> list[Course]:
         limit_per_term = None
-        if bail_after is not None:
-            limit_per_term = bail_after // len(term_ids)
+        if limit is not None:
+            limit_per_term = limit // len(term_ids)
 
         results: list[dict[str, Any]] = []
         for term_id in term_ids:
@@ -33,7 +33,7 @@ class AccountManager:
                 f'/accounts/{self.account_id}/courses',
                 params={ 'enrollment_term_id': term_id },
                 page_size=50,
-                bail_after=limit_per_term
+                limit=limit_per_term
             )
             results += term_results
         courses = [

--- a/migration/manager.py
+++ b/migration/manager.py
@@ -28,7 +28,7 @@ class AccountManager:
 
         results: list[dict[str, Any]] = []
         for i, term_id in enumerate(term_ids):
-            limit_for_term = limit_chunks[i] if limit_chunks else None
+            limit_for_term = limit_chunks[i] if limit_chunks is not None else None
             term_results = self.api.get_results_from_pages(
                 f'/accounts/{self.account_id}/courses',
                 params={ 'enrollment_term_id': term_id },

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -273,6 +273,14 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(chunks, [5, 5, 5, 4, 4])
         chunks = chunk_integer(14, 4)
         self.assertEqual(chunks, [4, 4, 3, 3])
+        chunks = chunk_integer(2, 3)
+        self.assertEqual(chunks, [1, 1, 0])
+        chunks = chunk_integer(0, 3)
+        self.assertEqual(chunks, [0, 0, 0])
+        with self.assertRaises(Exception):
+            chunks = chunk_integer(-1, 2)
+        with self.assertRaises(Exception):
+            chunks = chunk_integer(2, -1)
 
 
 class MainTestCase(unittest.TestCase):

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -10,7 +10,7 @@ from data import Course, ExternalTool, ExternalToolTab, ToolMigration
 from exceptions import ConfigException, InvalidToolIdsException
 from main import main, find_tools_for_migrations
 from manager import API, AccountManager, CourseManager
-from utils import convert_csv_to_int_list, find_entity_by_id
+from utils import convert_csv_to_int_list, find_entity_by_id, chunk_integer
 
 
 logger = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ class AccountManagerTestCase(unittest.TestCase):
         term_id_set = set(term_ids)
         self.assertTrue(len(term_id_set) == 1)
 
-    def test_manager_get_courses_in_multiple_term(self):
+    def test_manager_get_courses_in_multiple_terms(self):
         with self.api.client:
             manager = AccountManager(self.account_id, self.api)
             courses = manager.get_courses_in_terms(self.enrollment_term_ids, 150)
@@ -208,6 +208,16 @@ class UtilsTestCase(unittest.TestCase):
             convert_csv_to_int_list(',')
         with self.assertRaises(ConfigException):
             convert_csv_to_int_list('')
+
+    def test_chunk_integer(self):
+        chunks = chunk_integer(150, 3)
+        self.assertEqual(chunks, [50, 50, 50])
+        chunks = chunk_integer(5, 2)
+        self.assertEqual(chunks, [3, 2])
+        chunks = chunk_integer(23, 5)
+        self.assertEqual(chunks, [5, 5, 5, 4, 4])
+        chunks = chunk_integer(14, 4)
+        self.assertEqual(chunks, [4, 4, 3, 3])
 
 
 class MainTestCase(unittest.TestCase):

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -40,7 +40,7 @@ class APITestCase(unittest.TestCase):
             }
         }
         params = API.get_next_page_params(mock_response)
-        self.assertEqual(params, { 'page': ['2'], 'per_page': ['5'] })
+        self.assertEqual(params, {'page': ['2'], 'per_page': ['5']})
 
     def test_get_results_from_pages(self):
         with self.api.client:
@@ -76,7 +76,7 @@ class APITestCase(unittest.TestCase):
         bad_json_resp = httpx.Response(
             status_code=httpx.codes.OK,
             request=MagicMock(spec=httpx.Request),
-            text=json.dumps(self.course_data)[:-3],
+            text=json.dumps(self.course_data)[:-3], # Simulate malformed JSON
         )
         expected_resp = httpx.Response(
             status_code=httpx.codes.OK,

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -51,7 +51,7 @@ class APITestCase(unittest.TestCase):
 
 class AccountManagerTestCase(unittest.TestCase):
     """
-    Integration/unit tests for AccountManager class
+    Integration tests for AccountManager class
     """
 
     def setUp(self) -> None:
@@ -60,22 +60,6 @@ class AccountManagerTestCase(unittest.TestCase):
         self.account_id = int(os.getenv('ACCOUNT_ID', 0))
         self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
         self.api = API(api_url, api_key)
-
-        self.test_external_tool_tab = ExternalToolTab(
-            id='context_external_tool_99999',
-            label='Test External Tool',
-            tool_id=99999,
-            is_hidden=True,
-            position=30
-        )
-
-    def test_find_tab_by_tool_id_returns_tab(self):
-        tab = CourseManager.find_tab_by_tool_id(99999, [self.test_external_tool_tab])
-        self.assertTrue(isinstance(tab, ExternalToolTab))
-
-    def test_find_tab_by_tool_id_returns_none(self):
-        tab = CourseManager.find_tab_by_tool_id(100000, [self.test_external_tool_tab])
-        self.assertTrue(tab is None)
 
     def test_manager_gets_tools(self):
         with self.api.client:
@@ -122,7 +106,7 @@ class AccountManagerTestCase(unittest.TestCase):
 
 class CourseManagerTestCase(unittest.TestCase):
     """
-    Integration tests for CourseManager class
+    Integration/unit tests for CourseManager class
     """
 
     def setUp(self):
@@ -137,6 +121,22 @@ class CourseManagerTestCase(unittest.TestCase):
         )
         self.source_tool_id: int = int(os.getenv('SOURCE_TOOL_ID', '0'))
         self.target_tool_id: int = int(os.getenv('TARGET_TOOL_ID', '0'))
+
+        self.test_external_tool_tab = ExternalToolTab(
+            id='context_external_tool_99999',
+            label='Test External Tool',
+            tool_id=99999,
+            is_hidden=True,
+            position=30
+        )
+
+    def test_find_tab_by_tool_id_returns_tab(self):
+        tab = CourseManager.find_tab_by_tool_id(99999, [self.test_external_tool_tab])
+        self.assertTrue(isinstance(tab, ExternalToolTab))
+
+    def test_find_tab_by_tool_id_returns_none(self):
+        tab = CourseManager.find_tab_by_tool_id(100000, [self.test_external_tool_tab])
+        self.assertTrue(tab is None)
 
     def test_manager_gets_tool_tabs_in_course(self):
         with self.api.client:

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -112,13 +112,13 @@ class AccountManagerTestCase(unittest.TestCase):
     def setUp(self) -> None:
         api_url: str = os.getenv('API_URL', '')
         api_key: str = os.getenv('API_KEY', '')
-        self.account_id = int(os.getenv('TEST_ACCOUNT_ID', 0))
+        self.test_account_id = int(os.getenv('TEST_ACCOUNT_ID', 0))
         self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
         self.api = API(api_url, api_key)
 
     def test_manager_get_tools(self):
         with self.api.client:
-            manager = AccountManager(self.account_id, self.api)
+            manager = AccountManager(self.test_account_id, self.api)
             tools = manager.get_tools_installed_in_account()
         self.assertTrue(len(tools) > 0)
         for tool in tools:
@@ -127,7 +127,7 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_in_single_term(self):
         with self.api.client:
-            manager = AccountManager(self.account_id, self.api)
+            manager = AccountManager(self.test_account_id, self.api)
             courses = manager.get_courses_in_terms([self.enrollment_term_ids[0]], 150)
         self.assertTrue(len(courses) > 0)
         term_ids: list[int] = []
@@ -139,7 +139,7 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_in_multiple_terms(self):
         with self.api.client:
-            manager = AccountManager(self.account_id, self.api)
+            manager = AccountManager(self.test_account_id, self.api)
             courses = manager.get_courses_in_terms(self.enrollment_term_ids, 150)
         self.assertTrue(len(courses) > 0)
         term_ids: list[int] = []
@@ -151,7 +151,7 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_with_limit(self):
         with self.api.client:
-            manager = AccountManager(self.account_id, self.api)
+            manager = AccountManager(self.test_account_id, self.api)
             courses = manager.get_courses_in_terms(self.enrollment_term_ids, 50)
         self.assertTrue(len(courses) > 0)
         for course in courses:

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -112,11 +112,11 @@ class AccountManagerTestCase(unittest.TestCase):
     def setUp(self) -> None:
         api_url: str = os.getenv('API_URL', '')
         api_key: str = os.getenv('API_KEY', '')
-        self.account_id = int(os.getenv('ACCOUNT_ID', 0))
+        self.account_id = int(os.getenv('TEST_ACCOUNT_ID', 0))
         self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
         self.api = API(api_url, api_key)
 
-    def test_manager_gets_tools(self):
+    def test_manager_get_tools(self):
         with self.api.client:
             manager = AccountManager(self.account_id, self.api)
             tools = manager.get_tools_installed_in_account()

--- a/migration/utils.py
+++ b/migration/utils.py
@@ -29,3 +29,15 @@ def convert_csv_to_int_list(csv_string: str) -> list[int]:
         )
         raise exception
     return int_list
+
+
+def chunk_integer(value: int, num_chunks: int) -> list[int]:
+    chunks: list[int] = []
+    div_floor = (value // num_chunks)
+    remainder = value % div_floor
+    for i in range(num_chunks):
+        if i < remainder:
+            chunks.append(div_floor + 1)
+        else:
+            chunks.append(div_floor)
+    return chunks

--- a/migration/utils.py
+++ b/migration/utils.py
@@ -32,9 +32,14 @@ def convert_csv_to_int_list(csv_string: str) -> list[int]:
 
 
 def chunk_integer(value: int, num_chunks: int) -> list[int]:
+    if value < 0:
+        raise Exception('value parameter for chunk_integer must be zero or a positive integer.')
+    if num_chunks < 1:
+        raise Exception('num_chunks parameter for chunk_integer must be a positive integer.')
+
     chunks: list[int] = []
     div_floor = (value // num_chunks)
-    remainder = value % div_floor
+    remainder = value % div_floor if div_floor > 0 else value
     for i in range(num_chunks):
         if i < remainder:
             chunks.append(div_floor + 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 httpx==0.24.0
 python-dotenv==1.0.0
+tenacity==8.2.2


### PR DESCRIPTION
This PR aims to resolve #4.

To just test `API`:
```
python3 migration/tests.py APITestCase -v
```

To Do
- [x]  Improve `limit` logic
- [x] Create `API.get` and `API.put`.
- [x] Apply `tenacity.retry` to each
- [x] Add test case for `API`
- [x] Move some tests to the proper test case 
