### PR TITLE
Add `WarehouseAccountManager` class, `time_execution` decorator (#2, #5)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,15 @@
 API_URL=
 # API key with admin privileges
 API_KEY=
+
+# Data warehouse
+# Warehouse database parameters (name is database name)
+WH_HOST=
+WH_PORT=
+WH_NAME=
+WH_USER=
+WH_PASSWORD=
+
 # Account in which to search for tools and courses
 # Sub-accounts will include tools installed in parent accounts
 ACCOUNT_ID=

--- a/migration/db.py
+++ b/migration/db.py
@@ -1,0 +1,43 @@
+from enum import Enum
+from typing import TypedDict
+from urllib.parse import quote_plus
+
+import sqlalchemy
+
+
+class Dialect(Enum):
+    POSTGRES = 'postgresql'
+
+
+class DBParams(TypedDict):
+    host: str
+    port: str
+    name: str
+    user: str
+    password: str
+
+
+class DB:
+    engine: sqlalchemy.engine.Engine
+    connection: sqlalchemy.engine.Connection | None
+
+    def __init__(self, dialect: Dialect, params: DBParams):
+        params['password'] = quote_plus(params['password'])
+        core_string = '{user}:{password}@{host}:{port}/{name}'.format(**params)
+        self.engine = sqlalchemy.create_engine(f'{dialect.value}://{core_string}')
+
+    def get_connection(self) -> sqlalchemy.engine.Connection:
+        if self.connection is None:
+            self.connection = self.engine.connect()
+        return self.connection
+    
+    def close_connection(self) -> None:
+        if self.connection is not None:
+            self.connection.close()
+
+    def __enter__(self):
+        self.connection = self.engine.connect()
+
+    def __exit__(self, *args, **kwargs):
+        self.close_connection()
+        self.engine.dispose()

--- a/migration/main.py
+++ b/migration/main.py
@@ -9,7 +9,7 @@ from data import ExternalTool, ToolMigration
 from db import DB, Dialect
 from exceptions import InvalidToolIdsException
 from manager import AccountManagerFactory, CourseManager
-from utils import convert_csv_to_int_list, find_entity_by_id
+from utils import convert_csv_to_int_list, find_entity_by_id, time_execution
 
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ def find_tools_for_migrations(
     return tool_pairs
 
 
+@time_execution
 def main(api: API, account_id: int, term_ids: list[int], migrations: list[ToolMigration], db: DB | None = None):
     
     factory = AccountManagerFactory()

--- a/migration/main.py
+++ b/migration/main.py
@@ -1,12 +1,14 @@
 import logging
 import os
+from contextlib import nullcontext
 
 from dotenv import load_dotenv
 
 from api import API
 from data import ExternalTool, ToolMigration
+from db import DB, Dialect
 from exceptions import InvalidToolIdsException
-from manager import AccountManager, CourseManager
+from manager import AccountManagerFactory, CourseManager
 from utils import convert_csv_to_int_list, find_entity_by_id
 
 
@@ -34,10 +36,12 @@ def find_tools_for_migrations(
     return tool_pairs
 
 
-def main(api: API, account_id: int, term_ids: list[int], migrations: list[ToolMigration]):
-    account_manager = AccountManager(account_id, api)
+def main(api: API, account_id: int, term_ids: list[int], migrations: list[ToolMigration], db: DB | None = None):
     
-    with api.client:
+    factory = AccountManagerFactory()
+    account_manager = factory.get_manager(account_id, api, db)
+
+    with api.client, db if db is not None else nullcontext():  # type: ignore
         tools = account_manager.get_tools_installed_in_account()
         tool_pairs = find_tools_for_migrations(tools, migrations)
 
@@ -84,6 +88,32 @@ if __name__ == '__main__':
     account_id: int = int(os.getenv('ACCOUNT_ID', '0'))
     enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
 
+    wh_host = os.getenv('WH_HOST')
+    wh_port = os.getenv('WH_PORT')
+    wh_name = os.getenv('WH_NAME')
+    wh_user = os.getenv('WH_USER')
+    wh_password = os.getenv('WH_PASSWORD')
+
+    db: DB | None = None
+    if (
+        wh_host is not None and
+        wh_port is not None and
+        wh_name is not None and
+        wh_user is not None and
+        wh_password is not None
+    ):
+        logger.info('Warehouse connection is configured, so it will be used for some data fetching...')
+        db = DB(
+            Dialect.POSTGRES,
+            {
+                'host': wh_host,
+                'port': wh_port,
+                'name': wh_name,
+                'user': wh_user,
+                'password': wh_password
+            }
+        )
+
     source_tool_id: int = int(os.getenv('SOURCE_TOOL_ID', '0'))
     target_tool_id: int = int(os.getenv('TARGET_TOOL_ID', '0'))
 
@@ -91,5 +121,6 @@ if __name__ == '__main__':
         API(api_url, api_key),
         account_id,
         enrollment_term_ids,
-        [ToolMigration(source_id=source_tool_id, target_id=target_tool_id)]
+        [ToolMigration(source_id=source_tool_id, target_id=target_tool_id)],
+        db
     )

--- a/migration/main.py
+++ b/migration/main.py
@@ -44,11 +44,13 @@ def main(api: API, account_id: int, term_ids: list[int], migrations: list[ToolMi
 
     with api.client, db if db is not None else nullcontext():  # type: ignore
         tools = account_manager.get_tools_installed_in_account()
+        logger.info(f'Number of tools found in account {account_id}: {len(tools)}')
+
         tool_pairs = find_tools_for_migrations(tools, migrations)
 
         # get list of tools available in account
         courses = account_manager.get_courses_in_terms(term_ids)
-        logger.info(f'Number of tools found in account {account_id}: {len(tools)}')
+        logger.info(f'Number of courses found in account {account_id} for terms {term_ids}: {len(courses)}')
 
         for source_tool, target_tool in tool_pairs:
             logger.info(f'Source tool: {source_tool}')

--- a/migration/main.py
+++ b/migration/main.py
@@ -114,6 +114,8 @@ if __name__ == '__main__':
                 'password': wh_password
             }
         )
+    else:
+        logger.info('Warehouse connection is not configured, so falling back to only using the Canvas API...')
 
     source_tool_id: int = int(os.getenv('SOURCE_TOOL_ID', '0'))
     target_tool_id: int = int(os.getenv('TARGET_TOOL_ID', '0'))

--- a/migration/manager.py
+++ b/migration/manager.py
@@ -61,7 +61,6 @@ class AccountManager(AccountManagerBase):
             )
             for course_dict in results
         ]
-        logger.info(f'Number of courses found in account {self.account_id} for terms {term_ids}: {len(courses)}')
         return courses
 
 
@@ -122,7 +121,6 @@ class WarehouseAccountManager(AccountManagerBase):
                 name=result_dict['course_name'],
                 enrollment_term_id=int(result_dict['term_id'])
             ))
-        logger.info(f'Number of courses found in account {self.account_id} for terms {term_ids}: {len(courses)}')
         return courses
 
 

--- a/migration/manager.py
+++ b/migration/manager.py
@@ -115,10 +115,8 @@ class WarehouseAccountManager(AccountManagerBase):
         results = conn.execute(statement).all()
 
         courses = []
-        course_dicts = []
         for result in results:
             result_dict = result._asdict()
-            course_dicts.append(result_dict)
             courses.append(Course(
                 id=int(result_dict['course_id']),
                 name=result_dict['course_name'],

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -8,9 +8,10 @@ import httpx
 from dotenv import load_dotenv
 
 from data import Course, ExternalTool, ExternalToolTab, ToolMigration
+from db import DB, DBParams, Dialect
 from exceptions import ConfigException, InvalidToolIdsException
 from main import main, find_tools_for_migrations
-from manager import API, AccountManager, CourseManager
+from manager import API, AccountManager, CourseManager, WarehouseAccountManager
 from utils import convert_csv_to_int_list, find_entity_by_id, chunk_integer
 
 
@@ -115,10 +116,11 @@ class AccountManagerTestCase(unittest.TestCase):
         self.test_account_id = int(os.getenv('TEST_ACCOUNT_ID', 0))
         self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
         self.api = API(api_url, api_key)
+        self.account_id = int(os.getenv('ACCOUNT_ID', 0))
 
-    def test_manager_get_tools(self):
+    def test_manager_gets_tools(self):
         with self.api.client:
-            manager = AccountManager(self.test_account_id, self.api)
+            manager = AccountManager(self.account_id, self.api)
             tools = manager.get_tools_installed_in_account()
         self.assertTrue(len(tools) > 0)
         for tool in tools:
@@ -127,7 +129,7 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_in_single_term(self):
         with self.api.client:
-            manager = AccountManager(self.test_account_id, self.api)
+            manager = AccountManager(self.account_id, self.api)
             courses = manager.get_courses_in_terms([self.enrollment_term_ids[0]], 150)
         self.assertTrue(len(courses) > 0)
         term_ids: list[int] = []
@@ -139,8 +141,8 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_in_multiple_terms(self):
         with self.api.client:
-            manager = AccountManager(self.test_account_id, self.api)
-            courses = manager.get_courses_in_terms(self.enrollment_term_ids, 150)
+            manager = AccountManager(self.account_id, self.api)
+            courses = manager.get_courses_in_terms(self.enrollment_term_ids)
         self.assertTrue(len(courses) > 0)
         term_ids: list[int] = []
         for course in courses:
@@ -151,7 +153,59 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_with_limit(self):
         with self.api.client:
-            manager = AccountManager(self.test_account_id, self.api)
+            manager = AccountManager(self.account_id, self.api)
+            courses = manager.get_courses_in_terms(self.enrollment_term_ids, 50)
+        self.assertTrue(len(courses) > 0)
+        for course in courses:
+            self.assertTrue(isinstance(course, Course))
+        self.assertTrue(len(courses) <= 50)
+
+
+class WarehouseAccountManagerTestCase(unittest.TestCase):
+    """
+    Integration tests for WarehouseAccountManager class
+    """
+
+    def setUp(self) -> None:
+        wh_db_params: DBParams = {
+            "host": os.getenv('WH_HOST', ''),
+            "port": os.getenv('WH_PORT', ''),
+            "name": os.getenv('WH_NAME', ''),
+            "user": os.getenv('WH_USER', ''),
+            "password": os.getenv('WH_PASSWORD', '')
+        }
+
+        self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
+        self.db = DB(Dialect.POSTGRES, wh_db_params)
+        self.account_id = int(os.getenv('ACCOUNT_ID', 0))
+
+    def test_manager_get_courses_in_single_term(self):
+        with self.db:
+            manager = WarehouseAccountManager(account_id=self.account_id, db=self.db)
+            courses = manager.get_courses_in_terms([self.enrollment_term_ids[0]], 150)
+        self.assertTrue(len(courses) > 0)
+        term_ids: list[int] = []
+        for course in courses:
+            self.assertTrue(isinstance(course, Course))
+            term_ids.append(course.enrollment_term_id)
+        term_id_set = set(term_ids)
+        self.assertTrue(len(term_id_set) == 1)
+
+    def test_manager_get_courses_in_multiple_terms(self):
+        with self.db:
+            manager = WarehouseAccountManager(account_id=self.account_id, db=self.db)
+            courses = manager.get_courses_in_terms(self.enrollment_term_ids)
+        self.assertTrue(len(courses) > 0)
+        term_ids: list[int] = []
+        for course in courses:
+            self.assertTrue(isinstance(course, Course))
+            term_ids.append(course.enrollment_term_id)
+        term_id_set = set(term_ids)
+        self.assertTrue(len(term_id_set) > 1)
+
+    def test_manager_get_courses_with_limit(self):
+        with self.db:
+            manager = WarehouseAccountManager(self.account_id, self.db)
             courses = manager.get_courses_in_terms(self.enrollment_term_ids, 50)
         self.assertTrue(len(courses) > 0)
         for course in courses:

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -116,11 +116,10 @@ class AccountManagerTestCase(unittest.TestCase):
         self.test_account_id = int(os.getenv('TEST_ACCOUNT_ID', 0))
         self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
         self.api = API(api_url, api_key)
-        self.account_id = int(os.getenv('ACCOUNT_ID', 0))
 
     def test_manager_gets_tools(self):
         with self.api.client:
-            manager = AccountManager(self.account_id, self.api)
+            manager = AccountManager(self.test_account_id, self.api)
             tools = manager.get_tools_installed_in_account()
         self.assertTrue(len(tools) > 0)
         for tool in tools:
@@ -129,7 +128,7 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_in_single_term(self):
         with self.api.client:
-            manager = AccountManager(self.account_id, self.api)
+            manager = AccountManager(self.test_account_id, self.api)
             courses = manager.get_courses_in_terms([self.enrollment_term_ids[0]], 150)
         self.assertTrue(len(courses) > 0)
         term_ids: list[int] = []
@@ -141,7 +140,7 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_in_multiple_terms(self):
         with self.api.client:
-            manager = AccountManager(self.account_id, self.api)
+            manager = AccountManager(self.test_account_id, self.api)
             courses = manager.get_courses_in_terms(self.enrollment_term_ids)
         self.assertTrue(len(courses) > 0)
         term_ids: list[int] = []
@@ -153,7 +152,7 @@ class AccountManagerTestCase(unittest.TestCase):
 
     def test_manager_get_courses_with_limit(self):
         with self.api.client:
-            manager = AccountManager(self.account_id, self.api)
+            manager = AccountManager(self.test_account_id, self.api)
             courses = manager.get_courses_in_terms(self.enrollment_term_ids, 50)
         self.assertTrue(len(courses) > 0)
         for course in courses:
@@ -175,13 +174,25 @@ class WarehouseAccountManagerTestCase(unittest.TestCase):
             "password": os.getenv('WH_PASSWORD', '')
         }
 
+        api_url: str = os.getenv('API_URL', '')
+        api_key: str = os.getenv('API_KEY', '')
+        self.api = API(api_url, api_key)
+
         self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
         self.db = DB(Dialect.POSTGRES, wh_db_params)
-        self.account_id = int(os.getenv('ACCOUNT_ID', 0))
+        self.test_account_id = int(os.getenv('TEST_ACCOUNT_ID', 0))
+
+    def test_get_subaccount_ids(self):
+        with self.api.client:
+            manager = WarehouseAccountManager(account_id=self.test_account_id, db=self.db, api=self.api)
+            subaccount_ids = manager.get_subaccount_ids()
+        self.assertTrue(len(subaccount_ids) > 0)
+        for subaccount_id in subaccount_ids:
+            self.assertIsInstance(subaccount_id, int)
 
     def test_manager_get_courses_in_single_term(self):
-        with self.db:
-            manager = WarehouseAccountManager(account_id=self.account_id, db=self.db)
+        with self.db, self.api.client:
+            manager = WarehouseAccountManager(account_id=self.test_account_id, db=self.db, api=self.api)
             courses = manager.get_courses_in_terms([self.enrollment_term_ids[0]], 150)
         self.assertTrue(len(courses) > 0)
         term_ids: list[int] = []
@@ -192,8 +203,8 @@ class WarehouseAccountManagerTestCase(unittest.TestCase):
         self.assertTrue(len(term_id_set) == 1)
 
     def test_manager_get_courses_in_multiple_terms(self):
-        with self.db:
-            manager = WarehouseAccountManager(account_id=self.account_id, db=self.db)
+        with self.db, self.api.client:
+            manager = WarehouseAccountManager(account_id=self.test_account_id, db=self.db, api=self.api)
             courses = manager.get_courses_in_terms(self.enrollment_term_ids)
         self.assertTrue(len(courses) > 0)
         term_ids: list[int] = []
@@ -204,8 +215,8 @@ class WarehouseAccountManagerTestCase(unittest.TestCase):
         self.assertTrue(len(term_id_set) > 1)
 
     def test_manager_get_courses_with_limit(self):
-        with self.db:
-            manager = WarehouseAccountManager(self.account_id, self.db)
+        with self.db, self.api.client:
+            manager = WarehouseAccountManager(self.test_account_id, self.db, api=self.api)
             courses = manager.get_courses_in_terms(self.enrollment_term_ids, 50)
         self.assertTrue(len(courses) > 0)
         for course in courses:

--- a/migration/utils.py
+++ b/migration/utils.py
@@ -1,5 +1,7 @@
+import functools
 import logging
-from typing import TypeVar
+import time
+from typing import Callable, TypeVar
 
 from data import CanvasEntity
 from exceptions import ConfigException
@@ -46,3 +48,15 @@ def chunk_integer(value: int, num_chunks: int) -> list[int]:
         else:
             chunks.append(div_floor)
     return chunks
+
+
+def time_execution(callable: Callable) -> Callable:
+    @functools.wraps(callable)
+    def wrapper(*args, **kwargs):
+        start = time.time()
+        result = callable(*args, **kwargs)
+        end = time.time()
+        delta = end - start
+        logger.info(f'{callable.__qualname__} took {delta} seconds to complete.')
+        return result
+    return wrapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 httpx==0.24.0
+psycopg2-binary==2.9.6
 python-dotenv==1.0.0
+SQLAlchemy==1.4.48
 tenacity==8.2.2


### PR DESCRIPTION
This PR aims to resolve #2 and #5.

```
# Warehouse course fetching
python3 migration/tests.py WarehouseAccountManagerTestCase.get_courses_in_multiple_terms -v
# API version for comparison
python3 migration/tests.py AccountManagerTestCase.get_courses_in_multiple_terms -v
```

Notes
- I'm using `sqlalchemy` 1.4 instead of 2 because I had issues connecting to Redshift (UDW) using the newer version. Maybe this will be fixed in the future, or when you rewrite the query to use CD2, it will no longer be relevant.
- Testing this can be kind of strange because if you're pointing at Canvas test, any changes you make there won't be reflected in the warehouse until the next day or so. This is why I elected not to use database queries for finding what tools are in the navigation for each course. Anyways, for testing, choose an account that's been around for a while. I'm doing some testing to see if I can get exactly equivalent course lists between the API and the warehouse (so far they've been a few off).

Resources
- https://docs.sqlalchemy.org/en/14/core/index.html
- https://realpython.com/primer-on-python-decorators/