### PR TITLE
make `env` file optional; add `_CSV` to `ENROLLMENT_TERM_IDS`' name (iss. #25)

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -21,7 +21,7 @@ WH_PASSWORD=
 # Sub-accounts will include tools installed in parent accounts
 ACCOUNT_ID=
 # Enrollment term IDs separated by commas
-ENROLLMENT_TERM_IDS=
+ENROLLMENT_TERM_IDS_CSV=
 
 # ID of current tool to be phased out (i.e., hidden)
 SOURCE_TOOL_ID=

--- a/migration/main.py
+++ b/migration/main.py
@@ -111,12 +111,11 @@ if '__main__' == __name__:
     root_dir: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     env_file_name: str = os.path.join(root_dir, 'env')
 
-    if not os.path.exists(env_file_name):
-        logger.error(f'File "{env_file_name}" not found.  '
-                     'Please create one and try again.')
-        exit(1)
-
-    load_dotenv(env_file_name, verbose=True)
+    if os.path.exists(env_file_name):
+        load_dotenv(env_file_name, verbose=True)
+    else:
+        logger.info(f'File "{env_file_name}" not found.  '
+                     'Using existing environment.')
 
     # Set up logging
     log_level = os.getenv('LOG_LEVEL', logging.INFO)

--- a/migration/main.py
+++ b/migration/main.py
@@ -132,7 +132,7 @@ if '__main__' == __name__:
     api_key: str = os.getenv('API_KEY', '')
     account_id: int = int(os.getenv('ACCOUNT_ID', 0))
     enrollment_term_ids: list[int] = convert_csv_to_int_list(
-        os.getenv('ENROLLMENT_TERM_IDS', '0'))
+        os.getenv('ENROLLMENT_TERM_IDS_CSV', '0'))
 
     wh_host = os.getenv('WH_HOST')
     wh_port = os.getenv('WH_PORT')

--- a/migration/tests.py
+++ b/migration/tests.py
@@ -119,7 +119,7 @@ class AccountManagerTestCase(unittest.IsolatedAsyncioTestCase):
         api_url: str = os.getenv('API_URL', '')
         api_key: str = os.getenv('API_KEY', '')
         self.test_account_id = int(os.getenv('TEST_ACCOUNT_ID', 0))
-        self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
+        self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS_CSV', '0'))
         self.api = API(api_url, api_key)
 
     async def test_manager_get_tools(self):
@@ -183,7 +183,7 @@ class WarehouseAccountManagerTestCase(unittest.IsolatedAsyncioTestCase):
         api_key: str = os.getenv('API_KEY', '')
         self.api = API(api_url, api_key)
 
-        self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
+        self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS_CSV', '0'))
         self.db = DB(Dialect.POSTGRES, wh_db_params)
         self.test_account_id = int(os.getenv('TEST_ACCOUNT_ID', 0))
 
@@ -418,7 +418,7 @@ class MainTestCase(unittest.IsolatedAsyncioTestCase):
         api_key: str = os.getenv('API_KEY', '')
         self.api = API(api_url, api_key)
         self.account_id: int = int(os.getenv('ACCOUNT_ID', '0'))
-        self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS', '0'))
+        self.enrollment_term_ids: list[int] = convert_csv_to_int_list(os.getenv('ENROLLMENT_TERM_IDS_CSV', '0'))
 
         self.source_tool_id: int = int(os.getenv('SOURCE_TOOL_ID', '0'))
         self.target_tool_id: int = int(os.getenv('TARGET_TOOL_ID', '0'))


### PR DESCRIPTION
When this was being run on local machines only, the `env` file was required.  However, when run in OpenShift and launched by Jenkins, all environment variables will have values, either provided by a config map or variables filled in the Jenkins UI by the user.  That makes `env` optional, mostly good for local testing.

Also renamed `ENROLLMENT_TERM_IDS` to `ENROLLMENT_TERM_IDS_CSV` to better convey the format of its value.

Resolves #25.