### PR TITLE
resolve `PoolTimeout` errors (iss. #27)

### DIFF
--- a/migration/api.py
+++ b/migration/api.py
@@ -39,14 +39,15 @@ class API:
         url: str,
         key: str,
         endpoint_type: EndpointType = EndpointType.REST,
-        timeout: int = 10
+        timeout: float = 10.0
     ):
         headers = {'Authorization': f'Bearer {key}'}
+        timeoutsConfiguration = httpx.Timeout(timeout, pool=None)
         limits = httpx.Limits(max_connections=MAX_ASYNC_CONNS)
         self.client = httpx.AsyncClient(
             base_url=url + endpoint_type.value,
             headers=headers,
-            timeout=timeout,
+            timeout=timeoutsConfiguration,
             limits=limits
         )
 


### PR DESCRIPTION
According to HTTPX's documentation, in the [Fine tuning the configuration](https://www.python-httpx.org/advanced/#fine-tuning-the-configuration) section, a timeout can be set for waiting for a connection from the connection pool.  When that timeout is exceeded, a `PoolTimeout` exception is raised.  The HTTPX client configuration we had been using didn't specify a pool timeout, so the value was effectively 0.0s.  Experimentally, I found that setting any value greater than zero helped our application get connections from the pool without error.  HTTPX's documentation said the timeout may also be set to `None`, meaning it will never timeout, it will wait "forever".  There seems to be minimal risk to that, so I've set that as the timeout value.  We may want to look into making this configurable if we continue to use this API class.