### PR TITLE
Handle error from Canvas API (iss. #30)

### DIFF
--- a/migration/api.py
+++ b/migration/api.py
@@ -82,6 +82,9 @@ class API:
     )
     async def put(self, url: str, params: dict[str, Any] | None = None) -> Any:
         resp = await self.client.put(url=url, params=params)
+        if resp.status_code == httpx.codes.UNPROCESSABLE_ENTITY:
+            logger.warning(f"HTTP {resp.status_code}: PUT {resp.url}; response: '{resp.text}'")
+            return None
         resp.raise_for_status()
         return resp.json()
 

--- a/migration/manager.py
+++ b/migration/manager.py
@@ -165,14 +165,15 @@ class CourseManager:
 
     @classmethod
     def convert_data_to_tool_tab(cls, data: dict[str, Any]) -> ExternalToolTab:
-        tool_id = int(data['id'].replace(cls.id_prefix, ''))
-        return ExternalToolTab(
-            id=data['id'],
-            label=data['label'],
-            tool_id=tool_id,
-            is_hidden=('hidden' in data.keys() and data['hidden'] is True),
-            position=data['position']
-        )
+        if data is not None:
+            tool_id = int(data['id'].replace(cls.id_prefix, ''))
+            return ExternalToolTab(
+                id=data['id'],
+                label=data['label'],
+                tool_id=tool_id,
+                is_hidden=('hidden' in data.keys() and data['hidden'] is True),
+                position=data['position']
+            )
 
     def create_course_log_message(self, message: str) -> str:
         return f'{self.course} | {message}'
@@ -223,15 +224,17 @@ class CourseManager:
             else:
                 target_position = source_tab.position
                 new_target_tab = await self.update_tool_tab(tab=target_tab, is_hidden=False, position=target_position)
-                logger.info(self.create_course_log_message(
-                    f"Made available target tool in course's navigation: {new_target_tab}"
-                ))
+                if new_target_tab is not None:
+                    logger.info(self.create_course_log_message(
+                        f"Made available target tool in course's navigation: {new_target_tab}"
+                    ))
 
             # Always hide the source tool if it's available
             new_source_tab = await self.update_tool_tab(tab=source_tab, is_hidden=True)
-            logger.info(self.create_course_log_message(
-                f"Hid source tool in course's navigation: {new_source_tab}"
-            ))
+            if new_source_tab is not None:
+                logger.info(self.create_course_log_message(
+                    f"Hid source tool in course's navigation: {new_source_tab}"
+                ))
 
             return (new_source_tab, new_target_tab)
 


### PR DESCRIPTION
Resolves #30.

When HTTP 422 error occurs, log pertinent info and return `None`.  In the calling code, handle `None` responses.