### PR TITLE
disable term display temporarily (iss. #40)

### DIFF
--- a/migration/main.py
+++ b/migration/main.py
@@ -100,10 +100,10 @@ async def main(api: API, account_id: int, term_ids: list[int],
             account_name = await account_manager.get_name()
             logger.info(f'Account ({account_id}) name: {repr(account_name)}')
 
-            term_names = await account_manager.get_term_names(term_ids)
-            logger.info(f'Term names…')
-            for term_id in term_ids:
-                logger.info(f'  Term ({term_id}): {repr(term_names[term_id])}')
+            # term_names = await account_manager.get_term_names(term_ids)
+            logger.info(f'Term names… (temporarily disabled; see issue #40)')
+            # for term_id in term_ids:
+            #     logger.info(f'  Term ({term_id}): {repr(term_names[term_id])}')
 
             tools = await account_manager.get_tools_installed_in_account()
             logger.info(


### PR DESCRIPTION
A possible bug in the API is crashing the app when it tries to refer to a term number that wasn't found in the API results.  The term in question exists, but the API hasn't returned it.  Commenting out the lines fetching and printing the term as a quick fix until that can be investigated.